### PR TITLE
Remove expected tag prefix from trigger condition

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - "**"
     tags:
-      - "v*.*.*"
+      - "*.*.*"
   pull_request:
     branches:
       - "main"


### PR DESCRIPTION
This PR removes the 'v' tag prefix from the Github Action trigger condition for tags.